### PR TITLE
Add scheduled shopping reminder

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,6 +88,7 @@ dependencies {
     kapt(libs.room.compiler)
     implementation(libs.youtube)
     implementation(libs.gson)
+    implementation(libs.androidx.work.runtime.ktx)
     testImplementation(libs.junit)
 
     implementation(libs.kotlinx.coroutines.core)

--- a/app/src/main/java/com/silva021/tanalista/data/local/room/RoomDatabase.kt
+++ b/app/src/main/java/com/silva021/tanalista/data/local/room/RoomDatabase.kt
@@ -5,15 +5,22 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.silva021.tanalista.data.local.room.dao.Converters
 import com.silva021.tanalista.data.local.room.dao.ShoppingListDao
+import com.silva021.tanalista.data.local.room.dao.ShoppingReminderDao
 import com.silva021.tanalista.data.local.room.dto.ShoppingItemEntity
 import com.silva021.tanalista.data.local.room.dto.ShoppingListEntity
+import com.silva021.tanalista.data.local.room.dto.ShoppingReminderEntity
 
 @Database(
-    entities = [ShoppingListEntity::class, ShoppingItemEntity::class],
-    version = 1,
+    entities = [
+        ShoppingListEntity::class,
+        ShoppingItemEntity::class,
+        ShoppingReminderEntity::class
+    ],
+    version = 2,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun shoppingListDao(): ShoppingListDao
+    abstract fun shoppingReminderDao(): ShoppingReminderDao
 }

--- a/app/src/main/java/com/silva021/tanalista/data/local/room/dao/Converters.kt
+++ b/app/src/main/java/com/silva021/tanalista/data/local/room/dao/Converters.kt
@@ -2,6 +2,10 @@ package com.silva021.tanalista.data.local.room.dao
 
 import androidx.room.TypeConverter
 import com.silva021.tanalista.domain.model.UnitType
+import com.silva021.tanalista.domain.model.ReminderType
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 class Converters {
     @TypeConverter
@@ -9,4 +13,16 @@ class Converters {
 
     @TypeConverter
     fun toUnitType(value: String): UnitType = UnitType.valueOf(value)
+
+    @TypeConverter
+    fun fromLocalDateTime(date: LocalDateTime): Long = date.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+    @TypeConverter
+    fun toLocalDateTime(value: Long): LocalDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(value), ZoneId.systemDefault())
+
+    @TypeConverter
+    fun fromReminderType(value: ReminderType): String = value.name
+
+    @TypeConverter
+    fun toReminderType(value: String): ReminderType = ReminderType.valueOf(value)
 }

--- a/app/src/main/java/com/silva021/tanalista/data/local/room/dao/ShoppingReminderDao.kt
+++ b/app/src/main/java/com/silva021/tanalista/data/local/room/dao/ShoppingReminderDao.kt
@@ -1,0 +1,25 @@
+package com.silva021.tanalista.data.local.room.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.silva021.tanalista.data.local.room.dto.ShoppingReminderEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ShoppingReminderDao {
+    @Query("SELECT * FROM shopping_reminder")
+    fun getAll(): Flow<List<ShoppingReminderEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(reminder: ShoppingReminderEntity)
+
+    @Update
+    suspend fun update(reminder: ShoppingReminderEntity)
+
+    @Delete
+    suspend fun delete(reminder: ShoppingReminderEntity)
+}

--- a/app/src/main/java/com/silva021/tanalista/data/local/room/dto/ShoppingReminderEntity.kt
+++ b/app/src/main/java/com/silva021/tanalista/data/local/room/dto/ShoppingReminderEntity.kt
@@ -1,0 +1,25 @@
+package com.silva021.tanalista.data.local.room.dto
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "shopping_reminder",
+    foreignKeys = [
+        ForeignKey(
+            entity = ShoppingItemEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["itemId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("itemId")]
+)
+data class ShoppingReminderEntity(
+    @PrimaryKey val id: String,
+    val itemId: String,
+    val reminderType: String,
+    val nextReminder: Long
+)

--- a/app/src/main/java/com/silva021/tanalista/data/repository/ReminderRepository.kt
+++ b/app/src/main/java/com/silva021/tanalista/data/repository/ReminderRepository.kt
@@ -1,0 +1,11 @@
+package com.silva021.tanalista.data.repository
+
+import com.silva021.tanalista.domain.model.ShoppingReminder
+import kotlinx.coroutines.flow.Flow
+
+interface ReminderRepository {
+    fun getAllReminders(): Flow<List<ShoppingReminder>>
+    suspend fun addReminder(reminder: ShoppingReminder)
+    suspend fun updateReminder(reminder: ShoppingReminder)
+    suspend fun deleteReminder(reminder: ShoppingReminder)
+}

--- a/app/src/main/java/com/silva021/tanalista/data/repository/ReminderRepositoryImpl.kt
+++ b/app/src/main/java/com/silva021/tanalista/data/repository/ReminderRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.silva021.tanalista.data.repository
+
+import com.silva021.tanalista.data.local.room.dao.ShoppingReminderDao
+import com.silva021.tanalista.domain.mappers.toEntity
+import com.silva021.tanalista.domain.mappers.toModel
+import com.silva021.tanalista.domain.model.ShoppingReminder
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class ReminderRepositoryImpl(
+    private val dao: ShoppingReminderDao
+) : ReminderRepository {
+    override fun getAllReminders(): Flow<List<ShoppingReminder>> =
+        dao.getAll().map { list -> list.map { it.toModel() } }
+
+    override suspend fun addReminder(reminder: ShoppingReminder) {
+        dao.insert(reminder.toEntity())
+    }
+
+    override suspend fun updateReminder(reminder: ShoppingReminder) {
+        dao.update(reminder.toEntity())
+    }
+
+    override suspend fun deleteReminder(reminder: ShoppingReminder) {
+        dao.delete(reminder.toEntity())
+    }
+}

--- a/app/src/main/java/com/silva021/tanalista/di/Modules.kt
+++ b/app/src/main/java/com/silva021/tanalista/di/Modules.kt
@@ -6,6 +6,8 @@ import com.silva021.tanalista.ui.screen.register.RegisterViewModel
 import com.silva021.tanalista.data.local.room.AppDatabase
 import com.silva021.tanalista.data.repository.ShoppingRepository
 import com.silva021.tanalista.data.repository.ShoppingRepositoryImpl
+import com.silva021.tanalista.data.repository.ReminderRepository
+import com.silva021.tanalista.data.repository.ReminderRepositoryImpl
 import com.silva021.tanalista.domain.usecase.AddShoppingItemUseCase
 import com.silva021.tanalista.domain.usecase.AddShoppingListUseCase
 import com.silva021.tanalista.domain.usecase.CreateUserUseCase
@@ -22,6 +24,10 @@ import com.silva021.tanalista.domain.usecase.LogoutUserUseCase
 import com.silva021.tanalista.domain.usecase.ResetPasswordUseCase
 import com.silva021.tanalista.domain.usecase.UpdateShoppingItemUseCase
 import com.silva021.tanalista.domain.usecase.UpdateShoppingListUseCase
+import com.silva021.tanalista.domain.usecase.GetRemindersUseCase
+import com.silva021.tanalista.domain.usecase.AddReminderUseCase
+import com.silva021.tanalista.domain.usecase.UpdateReminderUseCase
+import com.silva021.tanalista.domain.usecase.DeleteReminderUseCase
 import com.silva021.tanalista.domain.usecase.UpdateUserUseCase
 import com.silva021.tanalista.ui.screen.login.LoginViewModel
 import com.silva021.tanalista.ui.screen.shopping.add.list.CreateListViewModel
@@ -48,6 +54,7 @@ val roomModule = module {
         Room.databaseBuilder(androidContext(), AppDatabase::class.java, "tanalista.db").build()
     }
     single { (get() as AppDatabase).shoppingListDao() }
+    single { (get() as AppDatabase).shoppingReminderDao() }
 }
 
 val usecasesModule = module {
@@ -73,5 +80,11 @@ val usecasesModule = module {
     factory { GetShoppingListByIdUseCase(get()) }
     factory { UpdateShoppingListUseCase(get()) }
 
+    factory { GetRemindersUseCase(get()) }
+    factory { AddReminderUseCase(get()) }
+    factory { UpdateReminderUseCase(get()) }
+    factory { DeleteReminderUseCase(get()) }
+
     single<ShoppingRepository> { ShoppingRepositoryImpl(get()) }
+    single<ReminderRepository> { ReminderRepositoryImpl(get()) }
 }

--- a/app/src/main/java/com/silva021/tanalista/domain/mappers/Mappers.kt
+++ b/app/src/main/java/com/silva021/tanalista/domain/mappers/Mappers.kt
@@ -2,10 +2,13 @@ package com.silva021.tanalista.domain.mappers
 
 import com.silva021.tanalista.data.local.room.dto.ShoppingItemEntity
 import com.silva021.tanalista.data.local.room.dto.ShoppingListEntity
+import com.silva021.tanalista.data.local.room.dto.ShoppingReminderEntity
 import com.silva021.tanalista.domain.model.CategoryType
 import com.silva021.tanalista.domain.model.ShoppingItem
 import com.silva021.tanalista.domain.model.ShoppingList
 import com.silva021.tanalista.domain.model.UnitType
+import com.silva021.tanalista.domain.model.ReminderType
+import com.silva021.tanalista.domain.model.ShoppingReminder
 
 fun ShoppingItemEntity.toModel(): ShoppingItem {
     return ShoppingItem(
@@ -42,5 +45,23 @@ fun ShoppingItem.toEntity(listId: String? = null): ShoppingItemEntity {
         quantity = quantity,
         minRequired = minRequired,
         unitType = unitType.name,
+    )
+}
+
+fun ShoppingReminderEntity.toModel(): ShoppingReminder {
+    return ShoppingReminder(
+        id = id,
+        itemId = itemId,
+        reminderType = ReminderType.valueOf(reminderType),
+        nextReminder = java.time.LocalDateTime.ofEpochSecond(nextReminder / 1000, 0, java.time.ZoneOffset.UTC)
+    )
+}
+
+fun ShoppingReminder.toEntity(): ShoppingReminderEntity {
+    return ShoppingReminderEntity(
+        id = id,
+        itemId = itemId,
+        reminderType = reminderType.name,
+        nextReminder = nextReminder.atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli()
     )
 }

--- a/app/src/main/java/com/silva021/tanalista/domain/model/ReminderType.kt
+++ b/app/src/main/java/com/silva021/tanalista/domain/model/ReminderType.kt
@@ -1,0 +1,11 @@
+package com.silva021.tanalista.domain.model
+
+/**
+ * Represents the type of reminder interval.
+ */
+enum class ReminderType {
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+    CUSTOM
+}

--- a/app/src/main/java/com/silva021/tanalista/domain/model/ShoppingReminder.kt
+++ b/app/src/main/java/com/silva021/tanalista/domain/model/ShoppingReminder.kt
@@ -1,0 +1,14 @@
+package com.silva021.tanalista.domain.model
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Model used to store an item reminder information.
+ */
+data class ShoppingReminder(
+    val id: String = UUID.randomUUID().toString(),
+    val itemId: String,
+    val reminderType: ReminderType,
+    val nextReminder: LocalDateTime
+)

--- a/app/src/main/java/com/silva021/tanalista/domain/usecase/AddReminderUseCase.kt
+++ b/app/src/main/java/com/silva021/tanalista/domain/usecase/AddReminderUseCase.kt
@@ -1,0 +1,8 @@
+package com.silva021.tanalista.domain.usecase
+
+import com.silva021.tanalista.data.repository.ReminderRepository
+import com.silva021.tanalista.domain.model.ShoppingReminder
+
+class AddReminderUseCase(private val repository: ReminderRepository) {
+    suspend operator fun invoke(reminder: ShoppingReminder) = repository.addReminder(reminder)
+}

--- a/app/src/main/java/com/silva021/tanalista/domain/usecase/DeleteReminderUseCase.kt
+++ b/app/src/main/java/com/silva021/tanalista/domain/usecase/DeleteReminderUseCase.kt
@@ -1,0 +1,8 @@
+package com.silva021.tanalista.domain.usecase
+
+import com.silva021.tanalista.data.repository.ReminderRepository
+import com.silva021.tanalista.domain.model.ShoppingReminder
+
+class DeleteReminderUseCase(private val repository: ReminderRepository) {
+    suspend operator fun invoke(reminder: ShoppingReminder) = repository.deleteReminder(reminder)
+}

--- a/app/src/main/java/com/silva021/tanalista/domain/usecase/GetRemindersUseCase.kt
+++ b/app/src/main/java/com/silva021/tanalista/domain/usecase/GetRemindersUseCase.kt
@@ -1,0 +1,7 @@
+package com.silva021.tanalista.domain.usecase
+
+import com.silva021.tanalista.data.repository.ReminderRepository
+
+class GetRemindersUseCase(private val repository: ReminderRepository) {
+    operator fun invoke() = repository.getAllReminders()
+}

--- a/app/src/main/java/com/silva021/tanalista/domain/usecase/UpdateReminderUseCase.kt
+++ b/app/src/main/java/com/silva021/tanalista/domain/usecase/UpdateReminderUseCase.kt
@@ -1,0 +1,8 @@
+package com.silva021.tanalista.domain.usecase
+
+import com.silva021.tanalista.data.repository.ReminderRepository
+import com.silva021.tanalista.domain.model.ShoppingReminder
+
+class UpdateReminderUseCase(private val repository: ReminderRepository) {
+    suspend operator fun invoke(reminder: ShoppingReminder) = repository.updateReminder(reminder)
+}

--- a/app/src/main/java/com/silva021/tanalista/ui/screen/shopping/add/shopping/AddShoppingItemContent.kt
+++ b/app/src/main/java/com/silva021/tanalista/ui/screen/shopping/add/shopping/AddShoppingItemContent.kt
@@ -2,6 +2,7 @@ package com.silva021.tanalista.ui.screen.shopping.add.shopping
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Switch
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.OutlinedTextField
@@ -48,11 +50,14 @@ fun AddShoppingItemContent(
     onAddShoppingItem: (ShoppingItem) -> Unit,
     onEditShoppingItem: (ShoppingItem) -> Unit = {},
     onBackPressed: () -> Unit,
+    onReminderChanged: (Boolean) -> Unit,
 ) {
     var name by remember { mutableStateOf(shoppingItem?.name ?: "") }
     var quantity by remember { mutableStateOf(shoppingItem?.quantity?.toString() ?: "") }
     var minimumQuantity by remember { mutableStateOf(shoppingItem?.minRequired?.toString() ?: "") }
     var unit by remember { mutableStateOf(shoppingItem?.unitType ?: UnitType.UNIT) }
+
+    var createReminder by remember { mutableStateOf(false) }
 
     val isEditing = shoppingItem != null
     val itemId = shoppingItem?.id ?: UUID.randomUUID().toString()
@@ -152,6 +157,22 @@ fun AddShoppingItemContent(
 
                     Spacer(modifier = Modifier.height(12.dp))
 
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(
+                            text = stringResource(R.string.label_create_reminder),
+                            modifier = Modifier.weight(1f)
+                        )
+                        Switch(checked = createReminder, onCheckedChange = {
+                            createReminder = it
+                            onReminderChanged(it)
+                        })
+                    }
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
                     Button(
                         onClick = {
                             val item = ShoppingItem(
@@ -192,6 +213,7 @@ fun AddShoppingItemContentPreview() {
     AddShoppingItemContent(
         listId = "12345",
         onAddShoppingItem = { /* salvar */ },
-        onBackPressed = { /* voltar */ }
+        onBackPressed = { /* voltar */ },
+        onReminderChanged = {}
     )
 }

--- a/app/src/main/java/com/silva021/tanalista/ui/screen/shopping/add/shopping/AddShoppingItemScreen.kt
+++ b/app/src/main/java/com/silva021/tanalista/ui/screen/shopping/add/shopping/AddShoppingItemScreen.kt
@@ -7,7 +7,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import com.silva021.tanalista.domain.model.ShoppingItem
+import com.silva021.tanalista.work.ReminderScheduler
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -18,6 +22,8 @@ fun AddShoppingItemScreen(
     onBack: () -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    var createReminder by remember { mutableStateOf(false) }
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         viewModel.getShoppingItemById(itemId)
@@ -40,11 +46,26 @@ fun AddShoppingItemScreen(
                 shoppingItem = state.shoppingItem,
                 onAddShoppingItem = { item ->
                     viewModel.add(listId, item)
+                    if (createReminder) {
+                        ReminderScheduler.schedule(
+                            context,
+                            item.name,
+                            java.time.LocalDateTime.now().plusDays(30)
+                        )
+                    }
                 },
                 onEditShoppingItem = { item ->
                     viewModel.update(item)
+                    if (createReminder) {
+                        ReminderScheduler.schedule(
+                            context,
+                            item.name,
+                            java.time.LocalDateTime.now().plusDays(30)
+                        )
+                    }
                 },
-                onBackPressed = onBack
+                onBackPressed = onBack,
+                onReminderChanged = { createReminder = it }
             )
         }
     }

--- a/app/src/main/java/com/silva021/tanalista/work/ReminderScheduler.kt
+++ b/app/src/main/java/com/silva021/tanalista/work/ReminderScheduler.kt
@@ -1,0 +1,23 @@
+package com.silva021.tanalista.work
+
+import android.content.Context
+import androidx.work.Data
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+object ReminderScheduler {
+    fun schedule(context: Context, itemName: String, reminderTime: LocalDateTime) {
+        val delay = Duration.between(LocalDateTime.now(), reminderTime).toMillis()
+        val data = Data.Builder()
+            .putString(ReminderWorker.KEY_ITEM_NAME, itemName)
+            .build()
+        val request = OneTimeWorkRequestBuilder<ReminderWorker>()
+            .setInitialDelay(delay, java.util.concurrent.TimeUnit.MILLISECONDS)
+            .setInputData(data)
+            .build()
+        WorkManager.getInstance(context).enqueue(request)
+    }
+}

--- a/app/src/main/java/com/silva021/tanalista/work/ReminderWorker.kt
+++ b/app/src/main/java/com/silva021/tanalista/work/ReminderWorker.kt
@@ -1,0 +1,68 @@
+package com.silva021.tanalista.work
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.silva021.tanalista.MainActivity
+import com.silva021.tanalista.R
+
+class ReminderWorker(
+    context: Context,
+    params: WorkerParameters
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val itemName = inputData.getString(KEY_ITEM_NAME) ?: return Result.failure()
+        createNotificationChannel()
+        showNotification(itemName)
+        return Result.success()
+    }
+
+    private fun showNotification(itemName: String) {
+        val intent = Intent(applicationContext, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(
+            applicationContext,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or (if (Build.VERSION.SDK_INT >= 23) PendingIntent.FLAG_IMMUTABLE else 0)
+        )
+
+        val builder = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_logo)
+            .setContentTitle("Hora de repor")
+            .setContentText("$itemName está acabando!")
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .addAction(
+                R.drawable.ic_logo,
+                "Adicionar à próxima compra",
+                pendingIntent
+            )
+
+        NotificationManagerCompat.from(applicationContext).notify(itemName.hashCode(), builder.build())
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Shopping Reminder",
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            val manager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        const val KEY_ITEM_NAME = "item_name"
+        const val CHANNEL_ID = "shopping_reminder"
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="placeholder_minimum_quantity">Quantidade mínima</string>
     <string name="action_save">Salvar</string>
     <string name="action_update">Atualizar</string>
+    <string name="label_create_reminder">Criar lembrete de compra</string>
     <string name="title_my_lists">Minhas Listas</string>
     <string name="text_no_lists">Você ainda não tem nenhuma lista</string>
     <string name="action_add">Adicionar</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ navigation = "2.9.0"
 koin = "4.0.0"
 youtube = "2024.02.25"
 startup = "1.2.0"
+work = "2.9.0"
 gson = "2.12.1"
 
 [bundles]
@@ -57,6 +58,7 @@ kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 youtube = { group = "io.github.ilyapavlovskii", name = "youtubeplayer-compose", version.ref = "youtube"  }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson"  }
 startup = {  group = "androidx.startup", name = "startup-runtime", version.ref = "startup" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 firebase-config-ktx = { module = "com.google.firebase:firebase-config-ktx" }


### PR DESCRIPTION
## Summary
- add ReminderType and ShoppingReminder models
- store reminders via new Room entity/DAO
- convert LocalDateTime and ReminderType in Room converters
- inject reminder repository and use cases
- schedule reminder notifications with WorkManager
- allow creating reminder when adding shopping item

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a35f77bcc83339fd93281fe2d8630